### PR TITLE
Fixes overwriting traces with multiple runs

### DIFF
--- a/spark_plugin/adapter/spark/src/main/java/com/asml/apa/wta/spark/driver/WtaDriverPlugin.java
+++ b/spark_plugin/adapter/spark/src/main/java/com/asml/apa/wta/spark/driver/WtaDriverPlugin.java
@@ -31,7 +31,7 @@ public class WtaDriverPlugin implements DriverPlugin {
 
   private static final String TOOL_VERSION = "spark-wta-generator-1_0";
 
-  private static final String CURRENT_TIME = String.valueOf(System.currentTimeMillis());
+  private static final String WTA_VERSION = "schema-1.0";
 
   private MetricStreamingEngine metricStreamingEngine;
 
@@ -62,7 +62,8 @@ public class WtaDriverPlugin implements DriverPlugin {
       RuntimeConfig runtimeConfig = RuntimeConfig.readConfig(configFile);
       metricStreamingEngine = new MetricStreamingEngine();
       OutputFile outputFile = new DiskOutputFile(Path.of(runtimeConfig.getOutputPath()));
-      WtaWriter wtaWriter = new WtaWriter(outputFile, "schema-1.0", CURRENT_TIME, TOOL_VERSION);
+      String currentTime = String.valueOf(System.currentTimeMillis());
+      WtaWriter wtaWriter = new WtaWriter(outputFile, WTA_VERSION, currentTime, TOOL_VERSION);
       sparkDataSource = new SparkDataSource(sparkCtx, runtimeConfig, metricStreamingEngine, wtaWriter);
       initListeners();
       executorVars.put("resourcePingInterval", String.valueOf(runtimeConfig.getResourcePingInterval()));

--- a/spark_plugin/pom.xml
+++ b/spark_plugin/pom.xml
@@ -577,15 +577,6 @@
           <mutationThreshold>60</mutationThreshold>
           <withHistory>true</withHistory>
         </configuration>
-        <executions>
-          <execution>
-            <id>pitest-mutation-coverage</id>
-            <phase>integration-test</phase>
-            <goals>
-              <goal>mutationCoverage</goal>
-            </goals>
-          </execution>
-        </executions>
         <dependencies>
           <!-- https://mvnrepository.com/artifact/org.pitest/pitest-junit5-plugin -->
           <dependency>
@@ -843,17 +834,6 @@
       <id>no-tests</id>
       <build>
         <plugins>
-          <!-- https://mvnrepository.com/artifact/org.pitest/pitest-maven -->
-          <plugin>
-            <groupId>org.pitest</groupId>
-            <artifactId>pitest-maven</artifactId>
-            <executions>
-              <execution>
-                <id>pitest-mutation-coverage</id>
-                <phase>none</phase>
-              </execution>
-            </executions>
-          </plugin>
           <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-surefire-plugin -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
@@ -1051,17 +1031,6 @@
             <executions>
               <execution>
                 <id>jacoco-merge</id>
-                <phase>none</phase>
-              </execution>
-            </executions>
-          </plugin>
-          <!-- https://mvnrepository.com/artifact/org.pitest/pitest-maven -->
-          <plugin>
-            <groupId>org.pitest</groupId>
-            <artifactId>pitest-maven</artifactId>
-            <executions>
-              <execution>
-                <id>pitest-mutation-coverage</id>
                 <phase>none</phase>
               </execution>
             </executions>


### PR DESCRIPTION
Creates a new timestamp at the setup of every writer instead of reusing the same timestamp throughout the application. Additionally removes PITest from the standard lifecycle as it started crashing again.

Closes #12 